### PR TITLE
Widen support for `OverloadedLabels`

### DIFF
--- a/src/Language/Haskell/Meta/Parse.hs
+++ b/src/Language/Haskell/Meta/Parse.hs
@@ -64,6 +64,7 @@ parseExp = parseExpWithExts
 #else
 parseExp = parseExpWithExts
     [ TypeApplications
+    , OverloadedLabels
     ]
 #endif
 

--- a/src/Language/Haskell/Meta/Translate.hs
+++ b/src/Language/Haskell/Meta/Translate.hs
@@ -247,8 +247,12 @@ toExp d (Expr.HsGetField _ expr locatedField) =
     extractFieldLabel _ = error "Don't know how to handle XHsFieldLabel constructor..."
   in
     TH.GetFieldE (toExp d (unLoc expr)) (unpackFS . unLoc . extractFieldLabel . unLoc $ locatedField)
+#endif
 
+#if MIN_VERSION_ghc(9, 2, 0)
 toExp _ (Expr.HsOverLabel _ fastString) = TH.LabelE (unpackFS fastString)
+#else
+toExp _ (Expr.HsOverLabel _ _ fastString) = TH.LabelE (unpackFS fastString)
 #endif
 
 toExp dynFlags e = todo "toExp" (showSDocDebug dynFlags . ppr $ e)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -23,12 +23,12 @@ spec = do
       let Right exp = parseExp "(.b.c.d)"
       let Just list = nonEmpty ["b", "c", "d"]
       exp `shouldBe` TH.ProjectionE list
+#endif
 
   describe "Overloaded labels" $ do
     it "parses labels" $ do
       let Right exp = parseExp "#name"
       exp `shouldBe` TH.LabelE "name"
-#endif
 
   describe "Type application" $ do
     it "parses application" $ do


### PR DESCRIPTION
`OverloadedLabels` were added way back in 8.0.1, so let's support them also on 9.0 and 8.10 😆 